### PR TITLE
force file with bad state to be removed during checkout

### DIFF
--- a/cpp/Osmosis/Client/CheckOut.cpp
+++ b/cpp/Osmosis/Client/CheckOut.cpp
@@ -89,15 +89,21 @@ void CheckOut::removeUnknownFiles( const DirList & digested, const DirList & lab
 		if ( label.find( entry.path ) == nullptr ) {
 			boost::filesystem::path absolute = _directory / entry.path;
 			std::string relative = entry.path.string();
-			if ( entry.path == leftOversFromPreviousFailedOsmosisAttemptThatWillAnywaysBeErased and
-					startsWith( entry.path.string(), leftOversFromPreviousFailedOsmosisAttemptThatWillAnywaysBeErasedPrefix ) )
-				continue;
-			if ( _ignores.parentOfAnIgnored( absolute ) )
-				continue;
-			if ( not boost::filesystem::exists( absolute ) and not boost::filesystem::symbolic_link_exists( absolute ) )
-				continue;
-			if ( areOneOrMoreAncestorsSymlinks( entry.path ) )
-				continue;
+
+			if (fileInValidCondition(absolute)) {
+				if ( entry.path == leftOversFromPreviousFailedOsmosisAttemptThatWillAnywaysBeErased and
+						startsWith( entry.path.string(), leftOversFromPreviousFailedOsmosisAttemptThatWillAnywaysBeErasedPrefix ) )
+					continue;
+				if ( _ignores.parentOfAnIgnored( absolute ) )
+					continue;
+
+				if ( not boost::filesystem::exists( absolute ) and not boost::filesystem::symbolic_link_exists( absolute ) )
+					continue;
+				if ( areOneOrMoreAncestorsSymlinks( entry.path ) )
+					continue;
+			} else
+				TRACE_INFO("Remove dangling file '" << absolute << "'");
+
 			try {
 				boost::filesystem::remove_all( absolute );
 			} catch ( boost::filesystem::filesystem_error &ex ) {

--- a/cpp/Osmosis/Client/CheckOut.h
+++ b/cpp/Osmosis/Client/CheckOut.h
@@ -53,6 +53,14 @@ private:
 		return false;
 	}
 
+	inline bool fileInValidCondition( const boost::filesystem::path entry ) const
+	{
+		boost::system::error_code file_error;
+		boost::filesystem::file_status status = boost::filesystem::status(entry, file_error);
+
+		return status != boost::filesystem::file_status(boost::filesystem::status_error);
+	}
+
 	void decideWhatToDo(    FetchFiles &                     fetchFiles,
 				const boost::filesystem::path &  path,
 				const FileStatus &               status,

--- a/tests/main.py
+++ b/tests/main.py
@@ -844,6 +844,15 @@ class Test(unittest.TestCase):
         self.assertEquals(self.client.readFile("aFile"), "123456")
         self.client.assertLargePathExists(largePath)
 
+    def test_CheckoutRecoversWhenDeleteUnknownFilesInBadFileState(self):
+        self.client.writeFile("aFile", "123456")
+        self.client.checkin("yuvu")
+        # Link that points to itself causes file to become in bad state
+        # trying to this link info will result in errno ELOOP
+        self.client.createSymlink(relTargetPath="a", relLinkPath="a")
+        self.client.checkout("yuvu", removeUnknownFiles=True)
+        self.assertEquals(self.client.readFile("aFile"), "123456")
+        self.assertFalse(os.path.exists('a'))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When removeUnknownFiles flag is specified during checkout stage, but file is in "bad state"
(for example symlink that points to itself, which can be created with ln -s link link), osmosis
fails to complete checkout. According to boost documentation this error state means that it was impossible
to determine file attributes and whether file actually exists or not. In this case it is better to dispose this file,
as it cannot be used anyhow. (see http://www.boost.org/doc/libs/1_44_0/libs/filesystem/v3/doc/reference.html#status)