### PR TITLE
Leastrecentlyused - ignore unexisting labels in labelLog

### DIFF
--- a/cpp/Osmosis/ObjectStore/LeastRecentlyUsed.cpp
+++ b/cpp/Osmosis/ObjectStore/LeastRecentlyUsed.cpp
@@ -100,6 +100,11 @@ void LeastRecentlyUsed::keepLabelsFromLabelLogUntilExceedingMaximumDiskUsage()
 			_alreadyProcessedLabels.emplace( entry.label );
 			continue;
 		}
+		if ( !_labels.exists( entry.label ))
+		{
+			_alreadyProcessedLabels.emplace( entry.label );
+			continue;
+		}
 		if ( _alreadyProcessedLabels.find( entry.label ) != _alreadyProcessedLabels.end() )
 			continue;
 


### PR DESCRIPTION
after using eraselabel operation, label is removed from label list. but
"leastrecentlyused" is iterating over the "labelLog" from there, the
label still exist. after reading the erased label, osmosis try to check
the size and throw execption.

this will prevent osmosis from interacting with those labels.

Issue:LBM1-8381